### PR TITLE
Toggle threshold visibility via a checkbox on the main screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+moc_*
+ui_*
+*.o
+qrc_*
+*.php
+*.stash
+Makefile
+Todour.app

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -143,6 +143,7 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->lv_activetags->hide(); //  Not being used yet
     ui->newVersionView->hide(); // This defaults to not being shown
     ui->cb_showaall->setChecked(settings.value(SETTINGS_SHOW_ALL,DEFAULT_SHOW_ALL).toBool());
+    ui->cb_threshold_inactive->setChecked(settings.value(SETTINGS_THRESHOLD_INACTIVE,DEFAULT_THRESHOLD_INACTIVE).toBool());
 
     setTray();
     setFontSize();
@@ -573,6 +574,13 @@ void MainWindow::on_cb_showaall_stateChanged(int arg1)
 {
     QSettings settings;
     settings.setValue(SETTINGS_SHOW_ALL,arg1);
+    on_pushButton_4_clicked();
+}
+
+void MainWindow::on_cb_threshold_inactive_stateChanged(int arg1)
+{
+    QSettings settings;
+    settings.setValue(SETTINGS_THRESHOLD_INACTIVE,arg1);
     on_pushButton_4_clicked();
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -68,6 +68,7 @@ private slots:
 
 
     void on_cb_showaall_stateChanged(int arg1);
+    void on_cb_threshold_inactive_stateChanged(int arg1);
 
     void iconActivated(QSystemTrayIcon::ActivationReason reason);
     void cleanup(); // Need to have a quit slot of my own to save settings and so on.

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -60,6 +60,13 @@
        </spacer>
       </item>
       <item>
+       <widget class="QCheckBox" name="cb_threshold_inactive">
+        <property name="text">
+         <string>Show Threshold</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="cb_showaall">
         <property name="text">
          <string>Show All</string>

--- a/todour-latest.php
+++ b/todour-latest.php
@@ -1,1 +1,1 @@
-<?php echo "2.14-dev" ?>
+<?php echo "2.19" ?>


### PR DESCRIPTION
This adds a Show Threshold checkbox which toggles the "Treat threshold as inactive" option.

![CleanShot 2020-09-20 at 14 37 53@2x](https://user-images.githubusercontent.com/607938/93719199-f08cc680-fb4e-11ea-91bc-28901bf0210d.png)

This might not be something you want in Todour, feel free to close this 🙂 

I find I usually like to get future threshold items out of the view and off my mind, but I often toggle it on briefly, such as if I need to update information on one of those items.

Thanks for Todour! I love Todour's simplicity, though I'm going to add some features I miss from SwiftoDo Desktop, such as an Append hotkey, Set Due Date / Threshold Date hotkeys, pressing enter on Search to jump to the todo list, word wrapping for long lines, Vim-style and other hotkeys, and possibly some type of saved filters.

Let me know if any of these changes would be useful for you, otherwise I can just maintain a fork of the project.